### PR TITLE
Pagination and Sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,4 @@
 2015-06-29 - Initial release
+2015-12-21 - Pagination support
+2015-12-21 - Sort support
+2015-12-21 - v1.0.0

--- a/README.md
+++ b/README.md
@@ -28,7 +28,4 @@ jsonApi.define({
 
  * Search, Find, Create, Delete, Update
  * Efficient lookups via appropriate indexes
-
-### To do
-
- * Filtering happens at the database layer
+ * Database layer filtering, pagination and sorting

--- a/lib/mongoHandler.js
+++ b/lib/mongoHandler.js
@@ -51,12 +51,15 @@ MongoStore._getRelationshipAttributeNames = function(attributes) {
 
 MongoStore._getSearchCriteria = function(relationships) {
   if (!relationships) return {};
+
   var relationshipNames = Object.getOwnPropertyNames(relationships);
   var criteria = relationshipNames.reduce(function(partialCriteria, relationshipName) {
     var relationshipId = relationships[relationshipName];
     partialCriteria[relationshipName + ".id"] = relationshipId;
     return partialCriteria;
   }, {});
+  debug("criteria>", JSON.stringify(criteria, null, 2));
+
   return criteria;
 };
 
@@ -77,6 +80,32 @@ MongoStore.prototype._createIndexesForRelationships = function(collection, relat
     return partialIndex;
   }, {});
   collection.createIndex(index);
+};
+
+
+MongoStore.prototype._applySort = function(request, cursor) {
+  if (!request.params.sort) return cursor;
+
+  var attribute = request.params.sort;
+  var order = 1;
+  attribute = String(attribute);
+  if (attribute[0] === "-") {
+    order = -1;
+    attribute = attribute.substring(1, attribute.length);
+  }
+  var sortParam = { };
+  sortParam[attribute] = order;
+  debug("sort>", sortParam);
+
+  return cursor.sort(sortParam);
+};
+
+
+MongoStore.prototype._applyPagination = function(request, cursor) {
+  if (!request.params.page) return cursor;
+
+  debug("pagination>", request.params.page.offset, request.params.page.limit);
+  return cursor.skip(request.params.page.offset).limit(request.params.page.limit);
 };
 
 
@@ -110,7 +139,7 @@ MongoStore.prototype.initialise = function(resourceConfig) {
 MongoStore.prototype.populate = function(callback) {
   var self = this;
   self._db.dropDatabase(function(err) {
-    if (err) return console.error("error dropping database");
+    if (err) return console.error("error dropping database", err.message);
     async.each(self.resourceConfig.examples, function(document, cb) {
       self.create({ params: {} }, document, cb);
     }, function(error) {
@@ -125,11 +154,23 @@ MongoStore.prototype.populate = function(callback) {
   Search for a list of resources, give a resource type.
  */
 MongoStore.prototype.search = function(request, callback) {
-  var collection = this._db.collection(request.params.type);
-  debug("relationships> " + JSON.stringify(request.params.relationships, null, 2));
+  var self = this;
+  var collection = self._db.collection(request.params.type);
   var criteria = MongoStore._getSearchCriteria(request.params.relationships);
-  debug("criteria> " + JSON.stringify(criteria, null, 2));
-  collection.find(criteria, { _id: 0 }).toArray(callback);
+
+  async.parallel({
+    resultSet: function(asyncCallback) {
+      var cursor = collection.find(criteria, { _id: 0 });
+      self._applySort(request, cursor);
+      self._applyPagination(request, cursor);
+      return cursor.toArray(asyncCallback);
+    },
+    totalRows: function(asyncCallback) {
+      return collection.find(criteria, { _id: 0 }).count(asyncCallback);
+    }
+  }, function(err, results) {
+    return callback(err, results.resultSet, results.totalRows);
+  });
 };
 
 
@@ -185,7 +226,7 @@ MongoStore.prototype.update = function(request, partialResource, callback) {
   var collection = this._db.collection(request.params.type);
   var documentId = MongoStore._mongoUuid(request.params.id);
   var partialDocument = _.omit(partialResource, function(value) { return value === undefined; });
-  debug("partialDocument> " + JSON.stringify(partialDocument, null, 2));
+  debug("partialDocument>", JSON.stringify(partialDocument, null, 2));
   collection.findOneAndUpdate({
     _id: documentId
   }, {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonapi-store-mongodb",
-  "version": "0.0.1-alpha",
+  "version": "1.0.0",
   "description": "MongoDB data store for jsonapi-server.",
   "main": "lib/mongoHandler.js",
   "repository": {
@@ -40,7 +40,7 @@
     "coveralls": "2.11.2",
     "plato": "1.5.0",
     "mocha-performance": "0.1.0",
-    "jsonapi-server": "0.16.0"
+    "jsonapi-server": "1.0.3"
   },
   "scripts": {
     "test": "./node_modules/mocha/bin/mocha --timeout 20000 -R spec ./test/*.js",


### PR DESCRIPTION
This PR brings us up to speed with jsonapi-server v1.0.3.

* Pagination is now supported and handled by mongo
* Sorting is now supported and handled by mongo
* Documentation tweaks

Running `npm test` (as per the CI build) will run the core jsonapi-server end-to-end test suite against this data store.

 * [x] +1
 * [ ] +1