### PR TITLE
Handle all filtering at the database layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,5 @@
 2015-12-21 - Pagination support
 2015-12-21 - Sort support
 2015-12-21 - v1.0.0
+2015-12-30 - Offload queries to Mongo
+2015-12-30 - v1.1.0

--- a/lib/mongoHandler.js
+++ b/lib/mongoHandler.js
@@ -53,15 +53,20 @@ MongoStore.prototype._getSearchCriteria = function(request) {
   var self = this;
   if (!request.params.filter) return { };
 
-  var criteria = Object.keys(request.params.filter).reduce(function(partialCriteria, attribute) {
+  var criteria = Object.keys(request.params.filter).map(function(attribute) {
     var attributeConfig = self.resourceConfig.attributes[attribute];
-    if (!attributeConfig) return partialCriteria;
+    // If the filter attribute doens't exist, skip it
+    if (!attributeConfig) return null;
 
     var values = request.params.filter[attribute];
+    // Relationships need to be queried via .id
     if (attributeConfig._settings) {
       attribute += ".id";
+      // Filters on nested resources should be skipped
+      if (values instanceof Object) return null;
     }
 
+    // Coerce values to an array to simplify the logic
     if (!(values instanceof Array)) values = [ values ];
     values = values.map(function(value) {
       if (value[0] === "<") return { $lt: value.substring(1) };
@@ -75,21 +80,15 @@ MongoStore.prototype._getSearchCriteria = function(request) {
       return tmp;
     });
 
-    partialCriteria[attribute] = values;
-    return partialCriteria;
-  }, { });
-
-  criteria = Object.keys(criteria).map(function(attribute) {
-    return { $or: criteria[attribute] };
+    return { $or: values };
+  }).filter(function(value) {
+    return value !== null;
   });
 
-  if (criteria.length > 0) {
-    criteria = { $and: criteria };
-  } else {
-    criteria = { };
+  if (criteria.length === 0) {
+    return { };
   }
-
-  return criteria;
+  return { $and: criteria };
 };
 
 

--- a/lib/mongoHandler.js
+++ b/lib/mongoHandler.js
@@ -1,8 +1,7 @@
 "use strict";
 var _ = {
   clone: require("lodash.clone"),
-  omit: require("lodash.omit"),
-  assign: require("lodash.assign")
+  omit: require("lodash.omit")
 };
 var async = require("async");
 var debug = require("./debugging");
@@ -31,7 +30,7 @@ MongoStore._isRelationshipAttribute = function(attribute) {
 
 
 MongoStore._toMongoDocument = function(resource) {
-  var document = _.clone(resource, true);
+  var document = _.omit(resource, function(value) { return value === undefined; });
   document._id = MongoStore._mongoUuid(document.id);
   return document;
 };

--- a/lib/mongoHandler.js
+++ b/lib/mongoHandler.js
@@ -1,7 +1,8 @@
 "use strict";
 var _ = {
   clone: require("lodash.clone"),
-  omit: require("lodash.omit")
+  omit: require("lodash.omit"),
+  assign: require("lodash.assign")
 };
 var async = require("async");
 var debug = require("./debugging");
@@ -49,17 +50,47 @@ MongoStore._getRelationshipAttributeNames = function(attributes) {
 };
 
 
-MongoStore._getSearchCriteria = function(relationships) {
-  if (!relationships) return {};
+MongoStore.prototype._getSearchCriteria = function(request) {
+  var self = this;
+  if (!request.params.filter) return { };
 
-  var relationshipNames = Object.getOwnPropertyNames(relationships);
-  var criteria = relationshipNames.reduce(function(partialCriteria, relationshipName) {
-    var relationshipId = relationships[relationshipName];
-    partialCriteria[relationshipName + ".id"] = relationshipId;
+  var criteria = Object.keys(request.params.filter).reduce(function(partialCriteria, attribute) {
+    var attributeConfig = self.resourceConfig.attributes[attribute];
+    if (!attributeConfig) return partialCriteria;
+
+    var values = request.params.filter[attribute];
+    if (!(values instanceof Array)) values = [ values ];
+    values = values.map(function(value) {
+      if (value[0] === "<") return { $lt: value.substring(1) };
+      if (value[0] === ">") return { $gt: value.substring(1) };
+      if (value[0] === "~") return new RegExp("^" + value.substring(1) + "$", "i");
+      if (value[0] === ":") return new RegExp(value.substring(1));
+      return value;
+    }).map(function(value) {
+      var tmp = { };
+      tmp[attribute] = value;
+      return tmp;
+    });
+
+    if (attributeConfig._settings) {
+      attribute += ".id";
+    }
+
+    partialCriteria[attribute] = values;
     return partialCriteria;
-  }, {});
-  debug("criteria>", JSON.stringify(criteria, null, 2));
+  }, { });
 
+  criteria = Object.keys(criteria).map(function(attribute) {
+    return { $or: criteria[attribute] };
+  });
+
+  if (criteria.length > 0) {
+    criteria = { $and: criteria };
+  } else {
+    criteria = { };
+  }
+
+  debug("criteria", JSON.stringify(criteria));
   return criteria;
 };
 
@@ -95,7 +126,7 @@ MongoStore.prototype._applySort = function(request, cursor) {
   }
   var sortParam = { };
   sortParam[attribute] = order;
-  debug("sort>", sortParam);
+  debug("sort", JSON.stringify(sortParam));
 
   return cursor.sort(sortParam);
 };
@@ -104,7 +135,7 @@ MongoStore.prototype._applySort = function(request, cursor) {
 MongoStore.prototype._applyPagination = function(request, cursor) {
   if (!request.params.page) return cursor;
 
-  debug("pagination>", request.params.page.offset, request.params.page.limit);
+  debug("pagination", request.params.page.offset, request.params.page.limit);
   return cursor.skip(request.params.page.offset).limit(request.params.page.limit);
 };
 
@@ -156,7 +187,7 @@ MongoStore.prototype.populate = function(callback) {
 MongoStore.prototype.search = function(request, callback) {
   var self = this;
   var collection = self._db.collection(request.params.type);
-  var criteria = MongoStore._getSearchCriteria(request.params.relationships);
+  var criteria = self._getSearchCriteria(request);
 
   async.parallel({
     resultSet: function(asyncCallback) {
@@ -180,7 +211,11 @@ MongoStore.prototype.search = function(request, callback) {
 MongoStore.prototype.find = function(request, callback) {
   var collection = this._db.collection(request.params.type);
   var documentId = MongoStore._mongoUuid(request.params.id);
-  collection.findOne({ _id: documentId }, { _id: 0 }, function(err, result) {
+
+  var criteria = this._getSearchCriteria(request);
+  criteria._id = documentId;
+
+  collection.findOne(criteria, { _id: 0 }, function(err, result) {
     if (err || !result) {
       return callback(MongoStore._notFoundError(request.params.type, request.params.id));
     }
@@ -226,7 +261,7 @@ MongoStore.prototype.update = function(request, partialResource, callback) {
   var collection = this._db.collection(request.params.type);
   var documentId = MongoStore._mongoUuid(request.params.id);
   var partialDocument = _.omit(partialResource, function(value) { return value === undefined; });
-  debug("partialDocument>", JSON.stringify(partialDocument, null, 2));
+  debug("partialDocument", JSON.stringify(partialDocument));
   collection.findOneAndUpdate({
     _id: documentId
   }, {
@@ -235,8 +270,8 @@ MongoStore.prototype.update = function(request, partialResource, callback) {
     returnOriginal: false,
     projection: { _id: 0 }
   }, function(err, result) {
-    debug("err>", JSON.stringify(err, null, 2));
-    debug("result>", JSON.stringify(result, null, 2));
+    debug("err", JSON.stringify(err));
+    debug("result", JSON.stringify(result));
     if (err) return callback(err);
     if (!result || !result.value) {
       return callback(MongoStore._notFoundError(request.params.type, request.params.id));

--- a/lib/mongoHandler.js
+++ b/lib/mongoHandler.js
@@ -1,6 +1,5 @@
 "use strict";
 var _ = {
-  clone: require("lodash.clone"),
   omit: require("lodash.omit")
 };
 var async = require("async");

--- a/lib/mongoHandler.js
+++ b/lib/mongoHandler.js
@@ -58,6 +58,10 @@ MongoStore.prototype._getSearchCriteria = function(request) {
     if (!attributeConfig) return partialCriteria;
 
     var values = request.params.filter[attribute];
+    if (attributeConfig._settings) {
+      attribute += ".id";
+    }
+
     if (!(values instanceof Array)) values = [ values ];
     values = values.map(function(value) {
       if (value[0] === "<") return { $lt: value.substring(1) };
@@ -70,10 +74,6 @@ MongoStore.prototype._getSearchCriteria = function(request) {
       tmp[attribute] = value;
       return tmp;
     });
-
-    if (attributeConfig._settings) {
-      attribute += ".id";
-    }
 
     partialCriteria[attribute] = values;
     return partialCriteria;

--- a/lib/mongoHandler.js
+++ b/lib/mongoHandler.js
@@ -223,7 +223,7 @@ MongoStore.prototype.find = function(request, callback) {
 MongoStore.prototype.create = function(request, newResource, callback) {
   var collection = this._db.collection(newResource.type);
   var document = MongoStore._toMongoDocument(newResource);
-  debug("inesrt", JSON.stringify(document));
+  debug("insert", JSON.stringify(document));
   collection.insertOne(document, function(err) {
     if (err) return callback(err);
     collection.findOne(document, { _id: 0 }, callback);

--- a/lib/mongoHandler.js
+++ b/lib/mongoHandler.js
@@ -90,7 +90,6 @@ MongoStore.prototype._getSearchCriteria = function(request) {
     criteria = { };
   }
 
-  debug("criteria", JSON.stringify(criteria));
   return criteria;
 };
 
@@ -126,7 +125,6 @@ MongoStore.prototype._applySort = function(request, cursor) {
   }
   var sortParam = { };
   sortParam[attribute] = order;
-  debug("sort", JSON.stringify(sortParam));
 
   return cursor.sort(sortParam);
 };
@@ -135,7 +133,6 @@ MongoStore.prototype._applySort = function(request, cursor) {
 MongoStore.prototype._applyPagination = function(request, cursor) {
   if (!request.params.page) return cursor;
 
-  debug("pagination", request.params.page.offset, request.params.page.limit);
   return cursor.skip(request.params.page.offset).limit(request.params.page.limit);
 };
 
@@ -156,7 +153,6 @@ MongoStore.prototype.initialise = function(resourceConfig) {
     return console.error("error connecting to MongoDB:", err.message);
   }).then(function() {
     var resourceName = resourceConfig.resource;
-    debug("initialising resource [" + resourceName + "]");
     var collection = self._db.collection(resourceName);
     self._createIndexesForRelationships(collection, self.relationshipAttributeNames);
     self.ready = true;
@@ -188,6 +184,7 @@ MongoStore.prototype.search = function(request, callback) {
   var self = this;
   var collection = self._db.collection(request.params.type);
   var criteria = self._getSearchCriteria(request);
+  debug("search", JSON.stringify(criteria));
 
   async.parallel({
     resultSet: function(asyncCallback) {
@@ -212,10 +209,8 @@ MongoStore.prototype.find = function(request, callback) {
   var collection = this._db.collection(request.params.type);
   var documentId = MongoStore._mongoUuid(request.params.id);
 
-  var criteria = this._getSearchCriteria(request);
-  criteria._id = documentId;
-
-  collection.findOne(criteria, { _id: 0 }, function(err, result) {
+  debug("findOne", JSON.stringify({ _id: documentId }));
+  collection.findOne({ _id: documentId }, { _id: 0 }, function(err, result) {
     if (err || !result) {
       return callback(MongoStore._notFoundError(request.params.type, request.params.id));
     }
@@ -230,6 +225,7 @@ MongoStore.prototype.find = function(request, callback) {
 MongoStore.prototype.create = function(request, newResource, callback) {
   var collection = this._db.collection(newResource.type);
   var document = MongoStore._toMongoDocument(newResource);
+  debug("inesrt", JSON.stringify(document));
   collection.insertOne(document, function(err) {
     if (err) return callback(err);
     collection.findOne(document, { _id: 0 }, callback);
@@ -261,7 +257,7 @@ MongoStore.prototype.update = function(request, partialResource, callback) {
   var collection = this._db.collection(request.params.type);
   var documentId = MongoStore._mongoUuid(request.params.id);
   var partialDocument = _.omit(partialResource, function(value) { return value === undefined; });
-  debug("partialDocument", JSON.stringify(partialDocument));
+  debug("findOneAndUpdate", JSON.stringify(partialDocument));
   collection.findOneAndUpdate({
     _id: documentId
   }, {
@@ -270,12 +266,16 @@ MongoStore.prototype.update = function(request, partialResource, callback) {
     returnOriginal: false,
     projection: { _id: 0 }
   }, function(err, result) {
-    debug("err", JSON.stringify(err));
-    debug("result", JSON.stringify(result));
-    if (err) return callback(err);
+    if (err) {
+      debug("err", JSON.stringify(err));
+      return callback(err);
+    }
+
     if (!result || !result.value) {
       return callback(MongoStore._notFoundError(request.params.type, request.params.id));
     }
+
+    debug("result", JSON.stringify(result));
     return callback(null, result.value);
   });
 };

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "async": "1.5.0",
     "debug": "2.2.0",
+    "lodash.assign": "3.2.0",
     "lodash.clone": "3.0.3",
     "lodash.omit": "3.1.0",
     "mongodb": "2.0.48"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   "dependencies": {
     "async": "1.5.0",
     "debug": "2.2.0",
-    "lodash.assign": "3.2.0",
     "lodash.clone": "3.0.3",
     "lodash.omit": "3.1.0",
     "mongodb": "2.0.48"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonapi-store-mongodb",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "MongoDB data store for jsonapi-server.",
   "main": "lib/mongoHandler.js",
   "repository": {
@@ -27,7 +27,6 @@
   "dependencies": {
     "async": "1.5.0",
     "debug": "2.2.0",
-    "lodash.clone": "3.0.3",
     "lodash.omit": "3.1.0",
     "mongodb": "2.0.48"
   },


### PR DESCRIPTION
All filtering now gets converted to a MongoDB query and is executed on the database.

Running the test suite with debugging enabled will reveal the mongo queries:
```
$ reset && DEBUG=jsonApi:store:* npm test
```
```
jsonApi:store:mongodb search {"$and":[{"$or":[{"id":"cc5cca2e-0dd8-4b95-8cfc-a11230e73116"},{"id":"d850ea75-4427-4f81-8595-039990aeede5"},{"id":"32fb0105-acaa-4adb-9ec4-8b49633695e1"},{"id":"ad3aa89e-9c5b-4ac9-a652-6670f9f27587"}]},{"$or":[{"firstname":"Mark"}]}]}
jsonApi:store:mongodb search {"$and":[{"$or":[{"title":{"$lt":"M"}}]}]}
```