### PR TITLE
adding handler.before_create/delete/update & after_create/delete/update

### DIFF
--- a/lib/mongoHandler.js
+++ b/lib/mongoHandler.js
@@ -318,7 +318,23 @@ MongoStore.prototype.update = co.wrap(function* (request, partialResource, callb
         });
     }
   }
-  var collection = self._db.collection(request.params.type);
+  var getColPromise = new Promise(function(resolve, reject){
+    self._db.collection(request.params.type,  {strict:true}, function(err, col){
+      if(err){
+          var msg = {
+            status: "500",
+            code: "Internal Server Error",
+            title: "Collection not found",
+            detail: err
+          }
+          callback(msg);
+        return reject(msg) 
+      }else{
+        return resolve(col)
+      }
+    } )
+  })
+  var collection = yield getColPromise;
   var documentId = MongoStore._mongoUuid(request.params.id);
   var partialDocument = _.omit(partialResource, function(value) { return value === undefined; });
   debug("findOneAndUpdate", JSON.stringify(partialDocument));

--- a/lib/mongoHandler.js
+++ b/lib/mongoHandler.js
@@ -9,6 +9,7 @@ var mongodb = require("mongodb");
 
 var MongoStore = module.exports = function MongoStore(config) {
   this._config = config;
+  this._initQueue = []
 };
 
 
@@ -142,18 +143,31 @@ MongoStore.prototype.initialise = function(resourceConfig) {
   if (!self._config.url) {
     return console.error("MongoDB url missing from configuration");
   }
-  self.resourceConfig = resourceConfig;
-  self.relationshipAttributeNames = MongoStore._getRelationshipAttributeNames(resourceConfig.attributes);
-  mongodb.MongoClient.connect(self._config.url).then(function(db) {
-    self._db = db;
-  }).catch(function(err) {
-    return console.error("error connecting to MongoDB:", err.message);
-  }).then(function() {
+  var initResource = function() {
     var resourceName = resourceConfig.resource;
     var collection = self._db.collection(resourceName);
     self._createIndexesForRelationships(collection, self.relationshipAttributeNames);
     self.ready = true;
-  });
+    self.on_initialise&&self.on_initialise(resourceName, collection)
+  }
+
+  self.resourceConfig = resourceConfig;
+  self.relationshipAttributeNames = MongoStore._getRelationshipAttributeNames(resourceConfig.attributes);
+
+  if(!self._db){
+    self._initQueue.push(initResource)
+    if(self._initQueue.length==1)
+    mongodb.MongoClient.connect(self._config.url).then(function(db) {
+      self._db = db;
+    }).catch(function(err) {
+      return console.error("error connecting to MongoDB:", err.message);
+    }).then(function(){
+      while(self._initQueue.length) self._initQueue.shift()()
+    });
+  } else {
+    initResource()
+  }
+
 };
 
 
@@ -220,13 +234,23 @@ MongoStore.prototype.find = function(request, callback) {
   Create (store) a new resource give a resource type and an object.
  */
 MongoStore.prototype.create = function(request, newResource, callback) {
+  var genFunc = function*(){
+  var self = this;
+  if(self.before_create){
+    if( (yield self.before_create(newResource.type, newResource, genFunc))===false) return callback('create canceled');
+  }
   var collection = this._db.collection(newResource.type);
   var document = MongoStore._toMongoDocument(newResource);
   debug("insert", JSON.stringify(document));
   collection.insertOne(document, function(err) {
     if (err) return callback(err);
-    collection.findOne(document, { _id: 0 }, callback);
+    collection.findOne(document, { _id: 0 }, function(err, doc){
+      if(self.after_create) return self.after_create.call(self, err, doc, function(){ callback(err, doc) });
+      callback(err, doc)
+    });
   });
+  }()
+  genFunc.next()
 };
 
 
@@ -234,6 +258,11 @@ MongoStore.prototype.create = function(request, newResource, callback) {
   Delete a resource, given a resource type and an id.
  */
 MongoStore.prototype.delete = function(request, callback) {
+  var genFunc = function*(){
+  var self = this;
+  if(self.before_delete){
+    if( (yield self.before_delete(request.params.type, request.params.id, genFunc)) ===false) return callback('delete canceled');
+  }
   var collection = this._db.collection(request.params.type);
   var documentId = MongoStore._mongoUuid(request.params.id);
   collection.deleteOne({ _id: documentId }, function(err, result) {
@@ -241,8 +270,11 @@ MongoStore.prototype.delete = function(request, callback) {
     if (result.deletedCount === 0) {
       return callback(MongoStore._notFoundError(request.params.type, request.params.id));
     }
+    if(self.after_delete) self.after_delete.call(self, err, result, request.params.type, request.params.id, function(){callback(err, result)})
     return callback(err, result);
   });
+  }()
+  genFunc.next()
 };
 
 
@@ -251,28 +283,42 @@ MongoStore.prototype.delete = function(request, callback) {
   partialResource contains a subset of changes that need to be merged over the original.
  */
 MongoStore.prototype.update = function(request, partialResource, callback) {
-  var collection = this._db.collection(request.params.type);
+  // tutpoint: maybe using co+promise to be simple
+  var genFunc = function*(){
+  var self = this;
+  if(self.before_update){
+    // tutpoint: ES6 yield Precedence
+     if( (yield self.before_update(request.params.type, request.params.id, partialResource, genFunc)) === false){
+        return callback('update canceled');
+      }
+  }
+  var collection = self._db.collection(request.params.type);
   var documentId = MongoStore._mongoUuid(request.params.id);
   var partialDocument = _.omit(partialResource, function(value) { return value === undefined; });
   debug("findOneAndUpdate", JSON.stringify(partialDocument));
-  collection.findOneAndUpdate({
-    _id: documentId
-  }, {
-    $set: partialDocument
-  }, {
-    returnOriginal: false,
-    projection: { _id: 0 }
-  }, function(err, result) {
-    if (err) {
-      debug("err", JSON.stringify(err));
-      return callback(err);
-    }
+  collection.findOne({_id: documentId}, {fields: { _id: 0 }}, function(e,oldDoc){
+    collection.findOneAndUpdate({
+      _id: documentId
+    }, {
+      $set: partialDocument
+    }, {
+      returnOriginal: false,
+      projection: { _id: 0 }
+    }, function(err, result) {
+      if (err) {
+        debug("err", JSON.stringify(err));
+        return callback(err);
+      }
 
-    if (!result || !result.value) {
-      return callback(MongoStore._notFoundError(request.params.type, request.params.id));
-    }
+      if (!result || !result.value) {
+        return callback(MongoStore._notFoundError(request.params.type, request.params.id));
+      }
 
-    debug("result", JSON.stringify(result));
-    return callback(null, result.value);
-  });
+      debug("result", JSON.stringify(result));
+      if(self.after_update) return self.after_update.call(self, null, oldDoc, result.value, function(){ return callback(null, result.value) } );
+      return callback(null, result.value);
+    });
+  })
+  }()
+  genFunc.next()
 };

--- a/lib/mongoHandler.js
+++ b/lib/mongoHandler.js
@@ -237,9 +237,15 @@ MongoStore.prototype.find = function(request, callback) {
 MongoStore.prototype.create = co.wrap(function* (request, newResource, callback) {
   var self = this;
   if(self.before_create){
-    try{ yield self.before_create(newResource.type, newResource) }catch(e){
-      return debug(e, 'create cancel'), callback('create canceled');
-    }
+    try{ yield self.before_create(newResource.type, newResource) } catch(e){
+      debug(e, 'create cancel')
+      return callback({
+          status: "500",
+          code: "Internal Server Error",
+          title: "Resource cannot be created",
+          detail: e
+        });
+      }
   }
   var collection = this._db.collection(newResource.type);
   var document = MongoStore._toMongoDocument(newResource);
@@ -261,7 +267,13 @@ MongoStore.prototype.delete = co.wrap(function* (request, callback) {
   var self = this;
   if(self.before_delete){
     try{ yield self.before_delete(request.params.type, request.params.id) } catch(e){
-      return debug(e, 'delete cancel'), callback('delete canceled');
+      debug(e, 'delete cancel')
+      return callback({
+          status: "500",
+          code: "Internal Server Error",
+          title: "Resource cannot be deleted",
+          detail: e
+        });
     }
   }
   var collection = this._db.collection(request.params.type);
@@ -286,7 +298,13 @@ MongoStore.prototype.update = co.wrap(function* (request, partialResource, callb
   var self = this;
   if(self.before_update){
      try{ yield self.before_update(request.params.type, request.params.id, partialResource) } catch(e){
-      return debug(e, 'update cancel'), callback('update canceled');
+      debug(e, 'update cancel')
+      return callback({
+          status: "500",
+          code: "Internal Server Error",
+          title: "Resource cannot be updated",
+          detail: e
+        });
     }
   }
   var collection = self._db.collection(request.params.type);

--- a/lib/mongoHandler.js
+++ b/lib/mongoHandler.js
@@ -6,6 +6,7 @@ var async = require("async");
 var debug = require("./debugging");
 var mongodb = require("mongodb");
 var co = require("co");
+var joi = require("joi");
 
 
 var MongoStore = module.exports = function MongoStore(config) {
@@ -58,6 +59,7 @@ MongoStore.prototype._getSearchCriteria = function(request) {
     var attributeConfig = self.resourceConfig.attributes[attribute];
     // If the filter attribute doens't exist, skip it
     if (!attributeConfig) return null;
+    var castValue=function(v, start){ return joi.attempt(v.substring(start||0), attributeConfig) }
 
     var values = request.params.filter[attribute];
     // Relationships need to be queried via .id
@@ -70,11 +72,11 @@ MongoStore.prototype._getSearchCriteria = function(request) {
     // Coerce values to an array to simplify the logic
     if (!(values instanceof Array)) values = [ values ];
     values = values.map(function(value) {
-      if (value[0] === "<") return { $lt: value.substring(1) };
-      if (value[0] === ">") return { $gt: value.substring(1) };
-      if (value[0] === "~") return new RegExp("^" + value.substring(1) + "$", "i");
-      if (value[0] === ":") return new RegExp(value.substring(1));
-      return value;
+      if (value[0] === "<") return value[1]==='=' ? { $lte: castValue(value,2) } : { $lt: castValue(value, 1) };
+      if (value[0] === ">") return value[1]==='=' ? { $gte: castValue(value,2) } : { $gt: castValue(value, 1) };
+      if (value[0] === "~") return new RegExp("^" + castValue( value, 1) + "$", "i");
+      if (value[0] === ":") return new RegExp( castValue( value, 1) );
+      return castValue(value);
     }).map(function(value) {
       var tmp = { };
       tmp[attribute] = value;
@@ -195,7 +197,16 @@ MongoStore.prototype.populate = function(callback) {
 MongoStore.prototype.search = function(request, callback) {
   var self = this;
   var collection = self._db.collection(request.params.type);
-  var criteria = self._getSearchCriteria(request);
+  try{
+    var criteria = self._getSearchCriteria(request);
+  }catch(e){
+    return callback({
+        status: "500",
+        code: "TypeError",
+        title: "TypeError",
+        detail: "输入错误"
+      })
+  }
   debug("search", JSON.stringify(criteria));
 
   async.parallel({

--- a/lib/mongoHandler.js
+++ b/lib/mongoHandler.js
@@ -5,6 +5,7 @@ var _ = {
 var async = require("async");
 var debug = require("./debugging");
 var mongodb = require("mongodb");
+var co = require("co");
 
 
 var MongoStore = module.exports = function MongoStore(config) {
@@ -233,11 +234,12 @@ MongoStore.prototype.find = function(request, callback) {
 /**
   Create (store) a new resource give a resource type and an object.
  */
-MongoStore.prototype.create = function(request, newResource, callback) {
-  var genFunc = function*(){
+MongoStore.prototype.create = co.wrap(function* (request, newResource, callback) {
   var self = this;
   if(self.before_create){
-    if( (yield self.before_create(newResource.type, newResource, genFunc))===false) return callback('create canceled');
+    try{ yield self.before_create(newResource.type, newResource) }catch(e){
+      return debug(e, 'create cancel'), callback('create canceled');
+    }
   }
   var collection = this._db.collection(newResource.type);
   var document = MongoStore._toMongoDocument(newResource);
@@ -249,19 +251,18 @@ MongoStore.prototype.create = function(request, newResource, callback) {
       callback(err, doc)
     });
   });
-  }()
-  genFunc.next()
-};
+});
 
 
 /**
   Delete a resource, given a resource type and an id.
  */
-MongoStore.prototype.delete = function(request, callback) {
-  var genFunc = function*(){
+MongoStore.prototype.delete = co.wrap(function* (request, callback) {
   var self = this;
   if(self.before_delete){
-    if( (yield self.before_delete(request.params.type, request.params.id, genFunc)) ===false) return callback('delete canceled');
+    try{ yield self.before_delete(request.params.type, request.params.id) } catch(e){
+      return debug(e, 'delete cancel'), callback('delete canceled');
+    }
   }
   var collection = this._db.collection(request.params.type);
   var documentId = MongoStore._mongoUuid(request.params.id);
@@ -273,24 +274,20 @@ MongoStore.prototype.delete = function(request, callback) {
     if(self.after_delete) self.after_delete.call(self, err, result, request.params.type, request.params.id, function(){callback(err, result)})
     return callback(err, result);
   });
-  }()
-  genFunc.next()
-};
+});
 
 
 /**
   Update a resource, given a resource type and id, along with a partialResource.
   partialResource contains a subset of changes that need to be merged over the original.
  */
-MongoStore.prototype.update = function(request, partialResource, callback) {
-  // tutpoint: maybe using co+promise to be simple
-  var genFunc = function*(){
+MongoStore.prototype.update = co.wrap(function* (request, partialResource, callback) {
+  // tutpoint: using co.wrap to instead of normal function, should callback with Promise!
   var self = this;
   if(self.before_update){
-    // tutpoint: ES6 yield Precedence
-     if( (yield self.before_update(request.params.type, request.params.id, partialResource, genFunc)) === false){
-        return callback('update canceled');
-      }
+     try{ yield self.before_update(request.params.type, request.params.id, partialResource) } catch(e){
+      return debug(e, 'update cancel'), callback('update canceled');
+    }
   }
   var collection = self._db.collection(request.params.type);
   var documentId = MongoStore._mongoUuid(request.params.id);
@@ -319,6 +316,4 @@ MongoStore.prototype.update = function(request, partialResource, callback) {
       return callback(null, result.value);
     });
   })
-  }()
-  genFunc.next()
-};
+});

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "async": "1.5.0",
+    "co": "^4.6.0",
     "debug": "2.2.0",
     "lodash.omit": "3.1.0",
     "mongodb": "2.0.48"


### PR DESCRIPTION
do you mind using co/Promise/generator to this lib? I've created this PR to be use as below:

````
handler.before_create = function(){
  return new Promise(function(resolve, reject){
    resolve()
    //reject('some thing wrong, cannot create')
  })
}

handler.after_create = function(err, doc, next){
  if(err) do_something()
  else do_something_with(doc)

  next && next()
}
````

