### PR TITLE
Connection Persistence

### DIFF
--- a/lib/mongoHandler.js
+++ b/lib/mongoHandler.js
@@ -144,10 +144,26 @@ MongoStore.prototype.initialise = function(resourceConfig) {
   }
   self.resourceConfig = resourceConfig;
   self.relationshipAttributeNames = MongoStore._getRelationshipAttributeNames(resourceConfig.attributes);
-  mongodb.MongoClient.connect(self._config.url).then(function(db) {
+  mongodb.MongoClient.connect(self._config.url, {
+    server: {
+      reconnectTries: 999999999,
+      reconnectInterval: 5000
+    }
+  }).then(function(db) {
     self._db = db;
+    self._db.on("close", function(err) {
+      console.error("mongodb connection closed:", err.message);
+      self.ready = false;
+      self._db.collection("Nope").findOne({ _id: 0 }, { _id: 0 }, function() {
+        console.error("mongodb connection is back");
+        self.ready = true;
+      });
+    });
   }).catch(function(err) {
-    return console.error("error connecting to MongoDB:", err.message);
+    console.error("mongodb connection failed:", err.message);
+    setTimeout(function() {
+      self.initialise(resourceConfig);
+    }, 5000);
   }).then(function() {
     var resourceName = resourceConfig.resource;
     var collection = self._db.collection(resourceName);
@@ -162,6 +178,8 @@ MongoStore.prototype.initialise = function(resourceConfig) {
  */
 MongoStore.prototype.populate = function(callback) {
   var self = this;
+  if (!self._db) return;
+
   self._db.dropDatabase(function(err) {
     if (err) return console.error("error dropping database", err.message);
     async.each(self.resourceConfig.examples, function(document, cb) {


### PR DESCRIPTION
This PR ensures the best possible user experience whilst undergoing database connectivity issues. By default, MongoDB will buffer all requests (so users will see hanging requests + timeouts) and it'll completely give up after 30 seconds. This isn't desirable behaviour for us. Here's the new behaviour:

**Use Case 1:** When the mongo instance is down on API start:
 1. Stop mongoDb `# /etc/init.d/mongodb stop`
 2. Start the example server `$ npm start`
 3. Make a [request](http://localhost:16006/rest/articles) and verify a HTTP 503 Unavailable
 4. Start mongoDb `# /etc/init.d/mongodb start`
 5. Wait a few seconds
 6. Repeat the above [request](http://localhost:16006/rest/articles) and verify a 200 OK

**Use Case 2:** When the mongo instance goes down during use:
 1. Start the example server `$ npm start`
 2. Make a [request](http://localhost:16006/rest/articles) and verify a 200 OK
 3. Stop mongoDb `# /etc/init.d/mongodb stop`
 4. Wait a few seconds
 5. Repeat the above [request](http://localhost:16006/rest/articles) and verify a HTTP 503 Unavailable
 6. Start mongoDb `# /etc/init.d/mongodb start`
 7. Wait a few seconds
 8. Repeat the above [request](http://localhost:16006/rest/articles) and verify a 200 OK

Feel free to start/stop MongoDB all you like, it should always reconnect. You can even try waiting for ~30 minutes, it'll still reconnect.
