### PR TITLE
Wrap mongo errors with json:api formatting

### DIFF
--- a/lib/mongoHandler.js
+++ b/lib/mongoHandler.js
@@ -100,6 +100,15 @@ MongoStore._notFoundError = function(type, id) {
   };
 };
 
+MongoStore._unknownError = function(err) {
+  return {
+    status: "500",
+    code: "EUNKNOWN",
+    title: "An unknown error has occured",
+    detail: err
+  };
+};
+
 
 MongoStore.prototype._createIndexesForRelationships = function(collection, relationshipAttributeNames) {
   var index = relationshipAttributeNames.reduce(function(partialIndex, name) {
@@ -212,7 +221,10 @@ MongoStore.prototype.search = function(request, callback) {
       return collection.find(criteria, { _id: 0 }).count(asyncCallback);
     }
   }, function(err, results) {
-    return callback(err, results.resultSet, results.totalRows);
+    if (err) {
+      return callback(MongoStore._unknownError);
+    }
+    return callback(null, results.resultSet, results.totalRows);
   });
 };
 
@@ -242,7 +254,7 @@ MongoStore.prototype.create = function(request, newResource, callback) {
   var document = MongoStore._toMongoDocument(newResource);
   debug("insert", JSON.stringify(document));
   collection.insertOne(document, function(err) {
-    if (err) return callback(err);
+    if (err) return callback(MongoStore._unknownError(err));
     collection.findOne(document, { _id: 0 }, callback);
   });
 };
@@ -255,11 +267,11 @@ MongoStore.prototype.delete = function(request, callback) {
   var collection = this._db.collection(request.params.type);
   var documentId = MongoStore._mongoUuid(request.params.id);
   collection.deleteOne({ _id: documentId }, function(err, result) {
-    if (err) return callback(err);
+    if (err) return callback(MongoStore._unknownError(err));
     if (result.deletedCount === 0) {
       return callback(MongoStore._notFoundError(request.params.type, request.params.id));
     }
-    return callback(err, result);
+    return callback(null, result);
   });
 };
 
@@ -283,7 +295,7 @@ MongoStore.prototype.update = function(request, partialResource, callback) {
   }, function(err, result) {
     if (err) {
       debug("err", JSON.stringify(err));
-      return callback(err);
+      return callback(MongoStore._unknownError(err));
     }
 
     if (!result || !result.value) {


### PR DESCRIPTION
Right now, if an error occurs in the MongoDB module, or there's some kind of network issue, the error from MongoDB will bubble up to the consumer, and that error won't conform to the json:api specification.

This PR ensures all errors are wrapped up with in correct format.