### PR TITLE
Improved non-string filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-- 2015-06-29 - Initial release
-- 2015-12-21 - Pagination support
-- 2015-12-21 - Sort support
-- 2015-12-21 - v1.0.0
-- 2015-12-30 - Offload queries to Mongo
-- 2015-12-30 - v1.1.0
-- 2016-01-21 - Robust MongoDB connection management
 - 2016-01-21 - v1.2.0
+- 2016-01-21 - Robust MongoDB connection management
+- 2015-12-30 - v1.1.0
+- 2015-12-30 - Offload queries to Mongo
+- 2015-12-21 - v1.0.0
+- 2015-12-21 - Sort support
+- 2015-12-21 - Pagination support
+- 2015-06-29 - Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- 2016-02-17 - v1.2.1
+- 2016-02-17 - Improved filtering by non-string attributes
 - 2016-01-21 - v1.2.0
 - 2016-01-21 - Robust MongoDB connection management
 - 2015-12-30 - v1.1.0

--- a/lib/mongoHandler.js
+++ b/lib/mongoHandler.js
@@ -54,7 +54,7 @@ MongoStore.prototype._getSearchCriteria = function(request) {
 
   var criteria = Object.keys(request.params.filter).map(function(attribute) {
     var attributeConfig = self.resourceConfig.attributes[attribute];
-    // If the filter attribute doens't exist, skip it
+    // If the filter attribute doesn't exist, skip it
     if (!attributeConfig) return null;
 
     var values = request.params.filter[attribute];

--- a/lib/mongoHandler.js
+++ b/lib/mongoHandler.js
@@ -5,11 +5,14 @@ var _ = {
 var async = require("async");
 var debug = require("./debugging");
 var mongodb = require("mongodb");
-
+var Joi = require("joi");
 
 var MongoStore = module.exports = function MongoStore(config) {
   this._config = config;
 };
+
+
+var FILTER_OPERATORS = ["<", ">", "~", ":"];
 
 
 /**
@@ -48,6 +51,36 @@ MongoStore._getRelationshipAttributeNames = function(attributes) {
 };
 
 
+MongoStore._splitFilterElement = function(filterElementStr) {
+  if (FILTER_OPERATORS.indexOf(filterElementStr[0]) !== -1) {
+    return { operator: filterElementStr[0], value: filterElementStr.substring(1) };
+  }
+  return { operator: null, value: filterElementStr };
+};
+
+
+MongoStore._filterElementToMongoExpr = function(attributeConfig, filterElementStr) {
+  var filterElement = MongoStore._splitFilterElement(filterElementStr);
+  var value = filterElement.value;
+  if (!attributeConfig._settings) {  // not a relationship attribute
+    var validationResult = attributeConfig.validate(filterElement.value);
+    if (validationResult.error) return null;
+    value = validationResult.value;
+  }
+  if (!filterElement.operator) return value;
+  if (["~", ":"].indexOf(filterElement.operator) !== -1 && typeof value !== "string") {
+    return null;
+  }
+  var mongoExpr = {
+    ">": { $gt: value },
+    "<": { $lt: value },
+    "~": new RegExp("^" + value + "$", "i"),
+    ":": new RegExp(value)
+  }[filterElement.operator];
+  return mongoExpr;
+};
+
+
 MongoStore.prototype._getSearchCriteria = function(request) {
   var self = this;
   if (!request.params.filter) return { };
@@ -65,27 +98,32 @@ MongoStore.prototype._getSearchCriteria = function(request) {
       if (values instanceof Object) return null;
     }
 
-    // Coerce values to an array to simplify the logic
-    if (!(values instanceof Array)) values = [ values ];
-    values = values.map(function(value) {
-      if (value[0] === "<") return { $lt: value.substring(1) };
-      if (value[0] === ">") return { $gt: value.substring(1) };
-      if (value[0] === "~") return new RegExp("^" + value.substring(1) + "$", "i");
-      if (value[0] === ":") return new RegExp(value.substring(1));
-      return value;
-    }).map(function(value) {
-      var tmp = { };
-      tmp[attribute] = value;
-      return tmp;
-    });
-
+    values = [].concat(values); // Coerce values to an array to simplify the logic
+    var filterElemForAttrToMongoExpr = MongoStore._filterElementToMongoExpr.bind(null, attributeConfig);
+    values = values.map(filterElemForAttrToMongoExpr);
+    values = values.reduce(function(mongoExpressions, mongoExpr) {
+      if (mongoExpr !== null) {
+        var mongoExprForAttr = { };
+        mongoExprForAttr[attribute] = mongoExpr;
+        mongoExpressions.push(mongoExprForAttr);
+      }
+      return mongoExpressions;
+    }, []);
+    if (values.length === 0) {
+      return null;
+    }
+    if (values.length === 1) {
+      return values[0];
+    }
     return { $or: values };
   }).filter(function(value) {
     return value !== null;
   });
-
   if (criteria.length === 0) {
     return { };
+  }
+  if (criteria.length === 1) {
+    return criteria[0];
   }
   return { $and: criteria };
 };
@@ -192,7 +230,11 @@ MongoStore.prototype.populate = function(callback) {
   self._db.dropDatabase(function(err) {
     if (err) return console.error("error dropping database", err.message);
     async.each(self.resourceConfig.examples, function(document, cb) {
-      self.create({ params: {} }, document, cb);
+      var validationResult = Joi.validate(document, self.resourceConfig.attributes);
+      if (validationResult.error) {
+        return cb(validationResult.error);
+      }
+      self.create({ params: {} }, validationResult.value, cb);
     }, function(error) {
       if (error) console.error("error creating example document:", error);
       return callback();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonapi-store-mongodb",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "MongoDB data store for jsonapi-server.",
   "main": "lib/mongoHandler.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -27,19 +27,20 @@
   "dependencies": {
     "async": "1.5.0",
     "debug": "2.2.0",
+    "joi": "6.10.1",
     "lodash.omit": "3.1.0",
     "mongodb": "2.0.48"
   },
   "devDependencies": {
-    "mocha": "2.2.5",
-    "mysql": "2.9.0",
-    "eslint": "0.24.1",
     "blanket": "1.1.7",
-    "mocha-lcov-reporter": "0.0.2",
     "coveralls": "2.11.2",
-    "plato": "1.5.0",
+    "eslint": "0.24.1",
+    "jsonapi-server": "1.3.2",
+    "mocha": "2.2.5",
+    "mocha-lcov-reporter": "0.0.2",
     "mocha-performance": "0.1.0",
-    "jsonapi-server": "1.0.3"
+    "plato": "1.5.0",
+    "v8-profiler": "^5.6.0"
   },
   "scripts": {
     "test": "./node_modules/mocha/bin/mocha --timeout 20000 -R spec ./test/*.js",


### PR DESCRIPTION
Following up on holidayextras/jsonapi-server#100, this PR implements improved support to filter by non-string resource attributes.

Run the new `jsonapi-server` systems tests with `npm test` and verify that all the system tests pass with this data store, including the ones that filter by an number attribute. Verify if the code changes look sane.

* [x] :smile_cat: 
* [x] :smile_cat: x :two: 