### PR TITLE
Fix index creation

### DIFF
--- a/lib/mongoHandler.js
+++ b/lib/mongoHandler.js
@@ -153,7 +153,10 @@ MongoStore.prototype._createIndexesForRelationships = function(collection, relat
     partialIndex[name + ".id"] = 1;
     return partialIndex;
   }, {});
-  collection.createIndex(index);
+
+  if (Object.keys(index).length) {
+    collection.createIndex(index);
+  }
 };
 
 

--- a/lib/mongoHandler.js
+++ b/lib/mongoHandler.js
@@ -148,17 +148,17 @@ MongoStore._unknownError = function(err) {
 };
 
 MongoStore.prototype._createIndexesForRelationships = function(collection, relationshipAttributeNames) {
-  if (!(relationshipAttributeNames instanceof Array) || !relationshipAttributeNames.length) { return }
+  if (!Array.isArray(relationshipAttributeNames) || !relationshipAttributeNames.length) return;
 
   var index = relationshipAttributeNames.reduce(function(partialIndex, name) {
     if (name) {
-      partialIndex.push([name + ".id", 1]);
+      partialIndex[name + ".id"] = 1;
     }
-
     return partialIndex;
-  }, []);
-
-  collection.ensureIndex(index);
+  }, {});
+  if (Object.keys(index).length) {
+    collection.createIndex(index);
+  }
 };
 
 MongoStore.prototype._applySort = function(request, cursor) {

--- a/lib/mongoHandler.js
+++ b/lib/mongoHandler.js
@@ -147,18 +147,19 @@ MongoStore._unknownError = function(err) {
   };
 };
 
-
 MongoStore.prototype._createIndexesForRelationships = function(collection, relationshipAttributeNames) {
+  if (!(relationshipAttributeNames instanceof Array) || !relationshipAttributeNames.length) { return }
+
   var index = relationshipAttributeNames.reduce(function(partialIndex, name) {
-    partialIndex[name + ".id"] = 1;
+    if (name) {
+      partialIndex.push([name + ".id", 1]);
+    }
+
     return partialIndex;
-  }, {});
+  }, []);
 
-  if (Object.keys(index).length) {
-    collection.createIndex(index);
-  }
+  collection.ensureIndex(index);
 };
-
 
 MongoStore.prototype._applySort = function(request, cursor) {
   if (!request.params.sort) return cursor;


### PR DESCRIPTION
Fixes #21. See #20.

This is a new branch because @slonofanya's fork repository seems to have been deleted. I've rescued his commits from the pull request branch in our repository so his contribution is noted.

I added an additional commit to use `Array.isArray` instead of `instanceof Array` which more robust and use the project's single statement return style.