### PR TITLE
Checks the result of a find before returning it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- 2016-04-07 - v1.2.2
+- 2016-04-07 - Error handling when creating a document
 - 2016-02-17 - v1.2.1
 - 2016-02-17 - Improved filtering by non-string attributes
 - 2016-01-21 - v1.2.0

--- a/lib/mongoHandler.js
+++ b/lib/mongoHandler.js
@@ -301,7 +301,11 @@ MongoStore.prototype.create = function(request, newResource, callback) {
   debug("insert", JSON.stringify(document));
   collection.insertOne(document, function(err) {
     if (err) return callback(MongoStore._unknownError(err));
-    collection.findOne(document, { _id: 0 }, callback);
+    collection.findOne(document, { _id: 0 }, function(findErr, result) {
+      if (findErr) return callback(err);
+      if (!result) return callback("Could not find document after insert");
+      return callback(null, result);
+    });
   });
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonapi-store-mongodb",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "MongoDB data store for jsonapi-server.",
   "main": "lib/mongoHandler.js",
   "repository": {


### PR DESCRIPTION
This PR adds some error handling when creating a new document.

We were not checking that the create was successful before trying to `find` it. This was causing an occasional uncaught exception.

- [x] This is more robust
- [x] This will help