### PR TITLE
Support ObjectId in documents.

### DIFF
--- a/lib/mongoHandler.js
+++ b/lib/mongoHandler.js
@@ -30,11 +30,6 @@ MongoStore._checkMinServerVersion = function() {
 };
 
 
-MongoStore._mongoUuid = function(uuid) {
-  return new mongodb.Binary(uuid, mongodb.Binary.SUBTYPE_UUID);
-};
-
-
 MongoStore._isRelationshipAttribute = function(attribute) {
   return attribute._settings && (attribute._settings.__one || attribute._settings.__many);
 };
@@ -70,6 +65,15 @@ MongoStore._filterElementToMongoExpr = function(filterElement) {
     ":": new RegExp(value)
   }[filterElement.operator];
   return mongoExpr;
+};
+
+
+MongoStore.prototype._mongoUuid = function(uuid) {
+    if(this._config.idType === 'objectId') {
+        return new mongodb.ObjectId(uuid);
+    }
+
+    return new mongodb.Binary(uuid, mongodb.Binary.SUBTYPE_UUID);
 };
 
 
@@ -259,7 +263,7 @@ MongoStore.prototype.search = function(request, callback) {
  */
 MongoStore.prototype.find = function(request, callback) {
   var collection = this._db.collection(request.params.type);
-  var documentId = MongoStore._mongoUuid(request.params.id);
+  var documentId = this._mongoUuid(request.params.id);
 
   debug("findOne", JSON.stringify({ _id: documentId }));
   collection.findOne({ _id: documentId }, { _id: 0 }, function(err, result) {
@@ -294,7 +298,7 @@ MongoStore.prototype.create = function(request, newResource, callback) {
  */
 MongoStore.prototype.delete = function(request, callback) {
   var collection = this._db.collection(request.params.type);
-  var documentId = MongoStore._mongoUuid(request.params.id);
+  var documentId = this._mongoUuid(request.params.id);
   collection.deleteOne({ _id: documentId }, function(err, result) {
     if (err) return callback(MongoStore._unknownError(err));
     if (result.deletedCount === 0) {
@@ -311,7 +315,7 @@ MongoStore.prototype.delete = function(request, callback) {
  */
 MongoStore.prototype.update = function(request, partialResource, callback) {
   var collection = this._db.collection(request.params.type);
-  var documentId = MongoStore._mongoUuid(request.params.id);
+  var documentId = this._mongoUuid(request.params.id);
   var partialDocument = _.omitBy(partialResource, function(value) { return value === undefined; });
   debug("findOneAndUpdate", JSON.stringify(partialDocument));
   collection.findOneAndUpdate({


### PR DESCRIPTION
The MongoStore can now be configured to store ids as ObjectId instead of binary UUID representation. 