### PR TITLE
populate with raw document instead of validated value

### DIFF
--- a/lib/mongoHandler.js
+++ b/lib/mongoHandler.js
@@ -217,7 +217,7 @@ MongoStore.prototype.populate = function(callback) {
       if (validationResult.error) {
         return cb(validationResult.error);
       }
-      self.create({ params: {} }, validationResult.value, cb);
+      self.create({ params: {} }, document, cb);
     }, function(error) {
       if (error) console.error("error creating example document:", error);
       return callback();


### PR DESCRIPTION
I was populating data from the resource examples where I had password field in attributes like this(to not give the password hash when searching/finding resource):
```
password: jsonApi.Joi.string().min(6).strip()
```

Unfortunately it also strips that password field off when populating. My suggestion is to populate using the raw document instead of the "validated.value". The validation check is there before the creation so using the document should not give any trouble.
