### PR TITLE
Remove strip() validation from attributes when populating database

### DIFF
--- a/lib/mongoHandler.js
+++ b/lib/mongoHandler.js
@@ -217,7 +217,7 @@ MongoStore.prototype.populate = function(callback) {
       if (validationResult.error) {
         return cb(validationResult.error);
       }
-      self.create({ params: {} }, validationResult.value, cb);
+      self.create({ params: {} }, document, cb);
     }, function(error) {
       if (error) console.error("error creating example document:", error);
       return callback();

--- a/lib/mongoHandler.js
+++ b/lib/mongoHandler.js
@@ -212,12 +212,19 @@ MongoStore.prototype.populate = function(callback) {
 
   self._db.dropDatabase(function(err) {
     if (err) return console.error("error dropping database", err.message);
+
+    var attrsWithoutStrip = Object.assign({}, self.resourceConfig.attributes);
+
+    // Remove strip flag from attribute validation to populate properly
+    Object.keys(attrsWithoutStrip).forEach(function(attrkey) {
+      delete attrsWithoutStrip[attrkey]._flags.strip;
+    });
     async.each(self.resourceConfig.examples, function(document, cb) {
-      var validationResult = Joi.validate(document, self.resourceConfig.attributes);
+      var validationResult = Joi.validate(document, attrsWithoutStrip);
       if (validationResult.error) {
         return cb(validationResult.error);
       }
-      self.create({ params: {} }, document, cb);
+      self.create({ params: {} }, validationResult.value, cb);
     }, function(error) {
       if (error) console.error("error creating example document:", error);
       return callback();


### PR DESCRIPTION
I was populating a database with some example users. Example users had field "password" and that is something you most definitely don't want to return when fetching resource. And that's why you would add `.strip()` to the password attribute validation. However when populating data to the database, you will want those stripped attributes also populated.