### PR TITLE
Fix deprecated messages from mongodb

### DIFF
--- a/lib/mongoHandler.js
+++ b/lib/mongoHandler.js
@@ -175,10 +175,8 @@ MongoStore.prototype.initialise = function(resourceConfig) {
   self.resourceConfig = resourceConfig;
   self.relationshipAttributeNames = MongoStore._getRelationshipAttributeNames(resourceConfig.attributes);
   mongodb.MongoClient.connect(self._config.url, {
-    server: {
-      reconnectTries: 999999999,
-      reconnectInterval: 5000
-    }
+    reconnectTries: 999999999,
+    reconnectInterval: 5000
   }).then(function(db) {
     self._db = db;
     self._db.on("close", function(err) {


### PR DESCRIPTION
MongoDB gives deprecation notifications when connecting because connect option attributes have moved to root level:
```
the server/replset/mongos options are deprecated, all their options are supported at the top level of the options object [poolSize,ssl,sslValidate,sslCA,sslCert,sslKey,sslPass,sslCRL,autoReconnect,noDelay,keepAlive,connectTimeoutMS,socketTimeoutMS,reconnectTries,reconnectInterval,ha,haInterval,replicaSet,secondaryAcceptableLatencyMS,acceptableLatencyMS,connectWithNoPrimary,authSource,w,wtimeout,j,forceServerObjectId,serializeFunctions,ignoreUndefined,raw,promoteLongs,bufferMaxEntries,readPreference,pkFactory,promiseLibrary,readConcern,maxStalenessSeconds,loggerLevel,logger,promoteValues,promoteBuffers,promoteLongs,domainsEnabled,keepAliveInitialDelay,checkServerIdentity,validateOptions]
```
This fix moves the server's options to root level.