### PR TITLE
Prevent crash when attributeConfig is null or undefined.

### DIFF
--- a/lib/mongoHandler.js
+++ b/lib/mongoHandler.js
@@ -81,7 +81,7 @@ MongoStore.prototype._getSearchCriteria = function(request) {
     var values = filter[attribute].map(MongoStore._filterElementToMongoExpr);
     var attributeConfig = self.resourceConfig.attributes[attribute];
     // Relationships need to be queried via .id
-    if (attributeConfig._settings) {
+    if (attributeConfig && attributeConfig._settings) {
       attribute += ".id";
     }
     values = values.reduce(function(mongoExpressions, mongoExpr) {


### PR DESCRIPTION
I can reliably crash my app when calling `filter[fieldname]=:somestring` with some fields (but not others) and any string.

```
jsonapi-store-mongodb/lib/mongoHandler.js:84
    if (attributeConfig._settings) {
                       ^

TypeError: Cannot read property '_settings' of undefined
```

This prevents this error.