### PR TITLE
Make ':contains' filter case insensitive; fixes #57

### DIFF
--- a/lib/mongoHandler.js
+++ b/lib/mongoHandler.js
@@ -67,7 +67,7 @@ MongoStore._filterElementToMongoExpr = function(filterElement) {
     ">": { $gt: value },
     "<": { $lt: value },
     "~": new RegExp("^" + value + "$", "i"),
-    ":": new RegExp(value)
+    ":": new RegExp(value, "i")
   }[filterElement.operator];
   return mongoExpr;
 };


### PR DESCRIPTION
The `:` filter should be case insensitive as is the case with [other store providers](https://github.com/holidayextras/jsonapi-store-relationaldb/blob/61c160ae9c13e5a37dcdd1e57962ce1eaf6680cd/lib/sqlHandler.js#L322-L325).